### PR TITLE
Make Travis-CI work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: objective-c
+  
+before_install:
+  - brew update
+  - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
+
+script: 
+- xctool clean build -project BitcoinSwift.xcodeproj -scheme BitcoinSwiftIOS -sdk iphonesimulator
+
+notifications:
+  irc: "chat.freenode.net#bitcoinswift"

--- a/BitcoinSwift.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/BitcoinSwift.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/BitcoinSwift.xcodeproj/xcshareddata/xcschemes/BitcoinSwiftIOS.xcscheme
+++ b/BitcoinSwift.xcodeproj/xcshareddata/xcschemes/BitcoinSwiftIOS.xcscheme
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A52ACCA195397080041541B"
+               BuildableName = "BitcoinSwift.framework"
+               BlueprintName = "BitcoinSwiftIOS"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A52ACD5195397080041541B"
+               BuildableName = "BitcoinSwiftIOSTests.xctest"
+               BlueprintName = "BitcoinSwiftIOSTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A2D51C219777320009B6B25"
+               BuildableName = "BitcoinSwiftIOSLiveTests.xctest"
+               BlueprintName = "BitcoinSwiftIOSLiveTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A52ACD5195397080041541B"
+               BuildableName = "BitcoinSwiftIOSTests.xctest"
+               BlueprintName = "BitcoinSwiftIOSTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A2D51C219777320009B6B25"
+               BuildableName = "BitcoinSwiftIOSLiveTests.xctest"
+               BlueprintName = "BitcoinSwiftIOSLiveTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A52ACCA195397080041541B"
+            BuildableName = "BitcoinSwift.framework"
+            BlueprintName = "BitcoinSwiftIOS"
+            ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A52ACCA195397080041541B"
+            BuildableName = "BitcoinSwift.framework"
+            BlueprintName = "BitcoinSwiftIOS"
+            ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A52ACCA195397080041541B"
+            BuildableName = "BitcoinSwift.framework"
+            BlueprintName = "BitcoinSwiftIOS"
+            ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BitcoinSwift.xcodeproj/xcshareddata/xcschemes/BitcoinSwiftOSX.xcscheme
+++ b/BitcoinSwift.xcodeproj/xcshareddata/xcschemes/BitcoinSwiftOSX.xcscheme
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0AC8CF1A19A934C800D93585"
+               BuildableName = "BitcoinSwift.framework"
+               BlueprintName = "BitcoinSwiftOSX"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0AC8CF2419A934C800D93585"
+               BuildableName = "BitcoinSwiftOSXTests.xctest"
+               BlueprintName = "BitcoinSwiftOSXTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0AECD0C319AAC5F400C11AC9"
+               BuildableName = "BitcoinSwiftOSXLiveTests.xctest"
+               BlueprintName = "BitcoinSwiftOSXLiveTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0AC8CF2419A934C800D93585"
+               BuildableName = "BitcoinSwiftOSXTests.xctest"
+               BlueprintName = "BitcoinSwiftOSXTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0AECD0C319AAC5F400C11AC9"
+               BuildableName = "BitcoinSwiftOSXLiveTests.xctest"
+               BlueprintName = "BitcoinSwiftOSXLiveTests"
+               ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0AC8CF1A19A934C800D93585"
+            BuildableName = "BitcoinSwift.framework"
+            BlueprintName = "BitcoinSwiftOSX"
+            ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0AC8CF1A19A934C800D93585"
+            BuildableName = "BitcoinSwift.framework"
+            BlueprintName = "BitcoinSwiftOSX"
+            ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0AC8CF1A19A934C800D93585"
+            BuildableName = "BitcoinSwift.framework"
+            BlueprintName = "BitcoinSwiftOSX"
+            ReferencedContainer = "container:BitcoinSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
These files will make Travis-CI work.
There are two steps to take before merging this pull request as outlined in [Getting Started](http://docs.travis-ci.com/user/getting-started/)
- Sign in to https://travis-ci.org
- Activate GitHub Webhook
  - Click on the switch for your repo on their dashboard

When this is set up, you can merge this pull request and Travis-CI should make a build, send you an email, and post to the IRC channel. This will happen every time a commit is done to any branch in the DoubleSha/BitcoinSwift repo, including master and pull requests.

The scheme files are needed because `xctest` and `xcodebuild` cannot automatically create schemes. This is currently the recommended way, and you can read more about it here:
- https://github.com/facebook/xctool/issues/120
- https://developer.apple.com/library/ios/recipes/xcode_help-scheme_editor/Articles/SchemeManage.html

I left out running the unit tests because they currently don't work. There's currently issues with the simulators on Travis-CI.
- http://status.travis-ci.com/incidents/y9pysslbxb79
