### PR TITLE
Fixes memory leak in OSKeyChainSecureDataStore

### DIFF
--- a/BitcoinSwift.xcodeproj/project.pbxproj
+++ b/BitcoinSwift.xcodeproj/project.pbxproj
@@ -515,6 +515,7 @@
 				0A52ACCC195397080041541B /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		0A52ACCC195397080041541B /* Products */ = {
 			isa = PBXGroup;

--- a/BitcoinSwift/OSKeyChainSecureDataStore.swift
+++ b/BitcoinSwift/OSKeyChainSecureDataStore.swift
@@ -25,18 +25,16 @@ public class OSKeyChainSecureDataStore: SecureDataStore {
     query.setObject(service, forKey: "\(kSecAttrService)")
     query.setObject(key, forKey: "\(kSecAttrAccount)")
     query.setObject(true, forKey: "\(kSecReturnData)")
-    let result = UnsafeMutablePointer<AnyObject?>.alloc(1)
-    result.initialize(nil)
-    let status = SecItemCopyMatching(query, result)
+    var result: CFTypeRef? = nil
+    let status = SecItemCopyMatching(query, &result)
     if status == errSecItemNotFound {
       return nil
     }
     if status != noErr {
       return nil
     }
-    let data = result.memory as? NSData
+    let data = result as! NSData
     let secureData = SecureData(data: data)
-    result.dealloc(1)
     return secureData
   }
 


### PR DESCRIPTION
Also marked project indentation as spaces in Xcode project file. This overrides the user's settings and avoid problems in the future :)