### PR TITLE
Creates public initializer in three Message classes

### DIFF
--- a/BitcoinSwift/Models/FilterClearMessage.swift
+++ b/BitcoinSwift/Models/FilterClearMessage.swift
@@ -12,6 +12,11 @@ import Foundation
 /// https://en.bitcoin.it/wiki/Protocol_specification#filterload.2C_filteradd.2C_filterclear.2C_merkleblock
 public struct FilterClearMessage: MessagePayload {
 
+  // Swift's default struct initializers are marked as internal
+  // See: http://stackoverflow.com/a/27635674/1470317
+  public init()
+  {}
+  
   public var command: Message.Command {
     return Message.Command.FilterClear
   }

--- a/BitcoinSwift/Models/FilterClearMessage.swift
+++ b/BitcoinSwift/Models/FilterClearMessage.swift
@@ -14,8 +14,7 @@ public struct FilterClearMessage: MessagePayload {
 
   // Swift's default struct initializers are marked as internal
   // See: http://stackoverflow.com/a/27635674/1470317
-  public init()
-  {}
+  public init() {}
   
   public var command: Message.Command {
     return Message.Command.FilterClear

--- a/BitcoinSwift/Models/GetPeerAddressMessage.swift
+++ b/BitcoinSwift/Models/GetPeerAddressMessage.swift
@@ -16,8 +16,7 @@ public struct GetPeerAddressMessage: MessagePayload {
 
   // Swift's default struct initializers are marked as internal
   // See: http://stackoverflow.com/a/27635674/1470317
-  public init()
-  {}
+  public init() {}
   
   public var command: Message.Command {
     return Message.Command.GetAddress

--- a/BitcoinSwift/Models/GetPeerAddressMessage.swift
+++ b/BitcoinSwift/Models/GetPeerAddressMessage.swift
@@ -14,6 +14,11 @@ import Foundation
 /// https://en.bitcoin.it/wiki/Protocol_specification#getaddr
 public struct GetPeerAddressMessage: MessagePayload {
 
+  // Swift's default struct initializers are marked as internal
+  // See: http://stackoverflow.com/a/27635674/1470317
+  public init()
+  {}
+  
   public var command: Message.Command {
     return Message.Command.GetAddress
   }

--- a/BitcoinSwift/Models/MemPoolMessage.swift
+++ b/BitcoinSwift/Models/MemPoolMessage.swift
@@ -14,6 +14,11 @@ import Foundation
 /// https://en.bitcoin.it/wiki/Protocol_specification#mempool
 public struct MemPoolMessage: MessagePayload {
 
+  // Swift's default struct initializers are marked as internal
+  // See: http://stackoverflow.com/a/27635674/1470317
+  public init()
+  {}
+  
   public var command: Message.Command {
     return Message.Command.MemPool
   }

--- a/BitcoinSwift/Models/MemPoolMessage.swift
+++ b/BitcoinSwift/Models/MemPoolMessage.swift
@@ -16,8 +16,7 @@ public struct MemPoolMessage: MessagePayload {
 
   // Swift's default struct initializers are marked as internal
   // See: http://stackoverflow.com/a/27635674/1470317
-  public init()
-  {}
+  public init() {}
   
   public var command: Message.Command {
     return Message.Command.MemPool


### PR DESCRIPTION
Swift's default struct initializers are marked as internal, so it is impossible to use them from other modules.
See: http://stackoverflow.com/a/27635674/1470317