### PR TITLE
Makes Network enum "extendable" by framework users (for altcoins)

### DIFF
--- a/BitcoinSwift/MessageParser.swift
+++ b/BitcoinSwift/MessageParser.swift
@@ -84,10 +84,14 @@ public class MessageParser {
       }
       let payloadData = NSData(bytes: receivedBytes, length: payloadLength)
       let message = Message(header: receivedHeader!, payloadData: payloadData)
-      if message.isChecksumValid() {
-        delegate?.didParseMessage(message)
+      if message.header.network == network {
+        if message.isChecksumValid() {
+          delegate?.didParseMessage(message)
+        } else {
+          Logger.warn("Dropping \(message.command.rawValue) message with invalid checksum")
+        }
       } else {
-        Logger.warn("Dropping \(message.command.rawValue) message with invalid checksum")
+        Logger.warn("Dropping \(message.command.rawValue) message with invalid network header: \(message.header.network) != \(network)")
       }
       receivedBytes.removeRange(0..<payloadLength)
       receivedHeader = nil

--- a/BitcoinSwift/MessageParser.swift
+++ b/BitcoinSwift/MessageParser.swift
@@ -18,7 +18,7 @@ public class MessageParser {
 
   public weak var delegate: MessageParserDelegate? = nil
 
-  private let network: Message.Network
+  private let network: NetworkMagicNumber
 
   // We receive a message in chunks. When we have received only part of a message, but not the
   // whole thing, receivedBytes stores the pending bytes, and adds onto it the next time
@@ -29,7 +29,7 @@ public class MessageParser {
   // enough bytes to parse the header, but haven't received the full message yet.
   private var receivedHeader: Message.Header? = nil
 
-  public init(network: Message.Network) {
+  public init(network: NetworkMagicNumber) {
     self.network = network
   }
 
@@ -46,7 +46,7 @@ public class MessageParser {
           // Throw away the bytes we have since we couldn't figure out how to handle them.
           // We might have all but the last byte of the networkMagicBytes for the next message,
           // so keep the last 3 bytes.
-          let end = receivedBytes.count - network.magicBytes.count + 1
+          let end = receivedBytes.count - network.magicBytes().count + 1
           if end > 0 {
             receivedBytes.removeRange(0..<end)
           }
@@ -67,7 +67,7 @@ public class MessageParser {
           // Failed to parse the header for some reason. It's possible that the networkMagicBytes
           // coincidentally appeared in the byte data, or the header was invalid for some reason.
           // Strip the networkMagicBytes so we can advance and try to parse again.
-          receivedBytes.removeRange(0..<network.magicBytes.count)
+          receivedBytes.removeRange(0..<network.magicBytes().count)
           continue
         }
         // receivedHeader is guaranteed to be non-nil at this point.
@@ -99,7 +99,7 @@ public class MessageParser {
   // Returns -1 if the header start (the position of network.magicBytes) was not found.
   // Otherwise returns the position where the message header begins.
   private func headerStartIndexInBytes(bytes: [UInt8]) -> Int {
-    let networkMagicBytes = network.magicBytes
+    let networkMagicBytes = network.magicBytes()
     if bytes.count < networkMagicBytes.count {
       return -1
     }

--- a/BitcoinSwift/Models/MessageHeader.swift
+++ b/BitcoinSwift/Models/MessageHeader.swift
@@ -21,7 +21,7 @@ extension Message {
   /// https://en.bitcoin.it/wiki/Protocol_specification#Message_structure
   public struct Header: Equatable {
 
-    public let network: Network
+    public let network: NetworkMagicNumber
     public let command: Command
     public let payloadLength: UInt32
     public let payloadChecksum: UInt32
@@ -29,7 +29,7 @@ extension Message {
     // Network (4 bytes) + Command (12 bytes) + payloadLength (4 bytes) + payloadChecksum (4 bytes).
     public static let length = 24
 
-    public init(network: Network,
+    public init(network: NetworkMagicNumber,
                 command: Command,
                 payloadLength: UInt32,
                 payloadChecksum: UInt32) {
@@ -45,7 +45,7 @@ extension Message.Header: BitcoinSerializable {
 
   public var bitcoinData: NSData {
     let bytes = NSMutableData()
-    bytes.appendUInt32(network.rawValue)
+    bytes.appendUInt32(network)
     bytes.appendData(command.data)
     bytes.appendUInt32(payloadLength)
     bytes.appendUInt32(payloadChecksum)
@@ -58,7 +58,7 @@ extension Message.Header: BitcoinSerializable {
       Logger.warn("Failed to parse network magic value in message header")
       return nil
     }
-    let network = Message.Network(rawValue: networkRaw!)
+    let network = Message.Network(rawValue: NetworkMagicNumber(networkRaw!))
     if network == nil {
       Logger.warn("Unsupported network \(networkRaw!) in message header")
       return nil
@@ -83,7 +83,7 @@ extension Message.Header: BitcoinSerializable {
       Logger.warn("Failed to parse payload checksum in message header")
       return nil
     }
-    return Message.Header(network: network!,
+    return Message.Header(network: network!.rawValue,
       command: command!,
       payloadLength: payloadLength!,
       payloadChecksum: payloadChecksum!)

--- a/BitcoinSwift/Models/MessageHeader.swift
+++ b/BitcoinSwift/Models/MessageHeader.swift
@@ -58,11 +58,6 @@ extension Message.Header: BitcoinSerializable {
       Logger.warn("Failed to parse network magic value in message header")
       return nil
     }
-    let network = Message.Network(rawValue: NetworkMagicNumber(networkRaw!))
-    if network == nil {
-      Logger.warn("Unsupported network \(networkRaw!) in message header")
-      return nil
-    }
     let commandRaw = stream.readASCIIStringWithLength(Message.Command.encodedLength)
     if commandRaw == nil {
       Logger.warn("Failed to parse command in message header")
@@ -83,7 +78,7 @@ extension Message.Header: BitcoinSerializable {
       Logger.warn("Failed to parse payload checksum in message header")
       return nil
     }
-    return Message.Header(network: network!.rawValue,
+    return Message.Header(network: NetworkMagicNumber(networkRaw!),
       command: command!,
       payloadLength: payloadLength!,
       payloadChecksum: payloadChecksum!)

--- a/BitcoinSwift/PeerConnection.swift
+++ b/BitcoinSwift/PeerConnection.swift
@@ -71,7 +71,7 @@ public class PeerConnection: NSObject, NSStreamDelegate, MessageParserDelegate {
 
   private let peerHostname: String?
   private let peerPort: UInt16
-  private let network: Message.Network
+  private let network: NetworkMagicNumber
 
   // Parses raw data received off the wire into Message objects.
   private let messageParser: MessageParser
@@ -99,7 +99,7 @@ public class PeerConnection: NSObject, NSStreamDelegate, MessageParserDelegate {
 
   public init(hostname: String,
               port: UInt16,
-              network: Message.Network,
+              network: NetworkMagicNumber,
               delegate: PeerConnectionDelegate? = nil,
               delegateQueue: NSOperationQueue = NSOperationQueue.mainQueue()) {
     self.delegate = delegate

--- a/BitcoinSwift/PeerController.swift
+++ b/BitcoinSwift/PeerController.swift
@@ -19,7 +19,7 @@ public class PeerController {
 
   private let hostname: String
   private let port: UInt16
-  private let network: Message.Network
+  private let network: NetworkMagicNumber
   private let queue: NSOperationQueue
   private let blockChainStore: BlockChainStore
   private var connection: PeerConnection?
@@ -29,7 +29,7 @@ public class PeerController {
 
   public init(hostname: String,
               port: UInt16,
-              network: Message.Network,
+              network: NetworkMagicNumber,
               blockChainStore: BlockChainStore,
               queue: NSOperationQueue = NSOperationQueue.mainQueue(),
               delegate: PeerControllerDelegate? = nil) {

--- a/BitcoinSwiftLiveTests/PeerConnectionLiveTest.swift
+++ b/BitcoinSwiftLiveTests/PeerConnectionLiveTest.swift
@@ -18,9 +18,9 @@ class PeerConnectionLiveTest: XCTestCase, PeerConnectionDelegate {
   }
 
   func testConnect() {
-    let conn = PeerConnection(hostname: "localhost",
+    let conn = PeerConnection(hostname: "anduck.net",
                               port: 8333,
-                              network: Message.Network.MainNet,
+                              network: Message.Network.MainNet.rawValue,
                               delegate: self)
     conn.connectWithVersionMessage(dummyVersionMessage(), timeout: 10)
     waitForExpectationsWithTimeout(10, handler: nil)

--- a/BitcoinSwiftLiveTests/PeerConnectionLiveTest.swift
+++ b/BitcoinSwiftLiveTests/PeerConnectionLiveTest.swift
@@ -18,7 +18,7 @@ class PeerConnectionLiveTest: XCTestCase, PeerConnectionDelegate {
   }
 
   func testConnect() {
-    let conn = PeerConnection(hostname: "anduck.net",
+    let conn = PeerConnection(hostname: "localhost",
                               port: 8333,
                               network: Message.Network.MainNet.rawValue,
                               delegate: self)

--- a/BitcoinSwiftTests/DummyMessage.swift
+++ b/BitcoinSwiftTests/DummyMessage.swift
@@ -15,7 +15,7 @@ class DummyMessage {
   // MARK: - VersionMessage
 
   class var versionMessage: Message {
-    return Message(network: .MainNet, payload: versionMessagePayload)
+    return Message(network: Message.Network.MainNet.rawValue, payload: versionMessagePayload)
   }
 
   class var versionMessagePayload: VersionMessage {

--- a/BitcoinSwiftTests/MessageHeaderTests.swift
+++ b/BitcoinSwiftTests/MessageHeaderTests.swift
@@ -25,7 +25,7 @@ class MessageHeaderTests: XCTestCase {
   override func setUp() {
     super.setUp()
     headerData = NSData(bytes: headerBytes, length: headerBytes.count)
-    header = Message.Header(network: network,
+    header = Message.Header(network: network.rawValue,
                             command: command,
                             payloadLength: 2,
                             payloadChecksum: 0xfa1358f1)

--- a/BitcoinSwiftTests/MessageParserTests.swift
+++ b/BitcoinSwiftTests/MessageParserTests.swift
@@ -19,7 +19,7 @@ class MessageParserTests: XCTestCase, MessageParserDelegate {
 
   override func setUp() {
     super.setUp()
-    messageParser = MessageParser(network: .MainNet)
+    messageParser = MessageParser(network: Message.Network.MainNet.rawValue)
     messageParser.delegate = self
   }
 

--- a/BitcoinSwiftTests/MessageTests.swift
+++ b/BitcoinSwiftTests/MessageTests.swift
@@ -57,7 +57,7 @@ class MessageTests: XCTestCase {
     super.setUp()
     payloadData = NSData(bytes: payloadBytes, length: payloadBytes.count)
     messageData = NSData(bytes: messageBytes, length: messageBytes.count)
-    message = Message(network: network, command: command, payloadData: payloadData)
+    message = Message(network: network.rawValue, command: command, payloadData: payloadData)
   }
 
   func testMessageEncoding() {

--- a/BitcoinSwiftTests/PeerConnectionTests.swift
+++ b/BitcoinSwiftTests/PeerConnectionTests.swift
@@ -29,7 +29,7 @@ class PeerConnectionTests: XCTestCase {
       self.outputStream = outputStream
       super.init(hostname: hostname,
                  port: port,
-                 network: network,
+                 network: network.rawValue,
                  delegate: delegate,
                  delegateQueue: delegateQueue)
     }


### PR DESCRIPTION
Since Swift enums are neither extendable or inheritable, it was impossible to "add" values to the Network enum, making it impossible to use BitcoinSwift for altcoins without changing the Message.Network source code.

Now, all network functions that required a Message.Network parameter do require a NetworkMagicNumber parameter instead. This allows a library user to simply use, for example, `NetworkMagicNumber(0xdbb6c0fb)` for Litecoin.

I am aware that this reduces the value safety, but since enums are rather limited in Swift, I was not able to find any other alternatives. Please suggest alternatives if you think of any.
